### PR TITLE
Algorithmic improvements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ let out_port = graph.port(output, DefaultPortType::Audio, "mixbus")?;
 graph.connect(port1, out_port)?;
 graph.connect(port2, out_port)?;
 
-let schedule = graph.compile(output);
+let schedule = graph.compile();
 for entry in schedule {
     let node_name = entry.node;
     // inputs may have multiple buffers to handle.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,14 +507,12 @@ where
             if node == src {
                 return Err(Error::Cycle);
             }
-            queue.extend(self.dependents(node).filter(|n| {
-                if queued.contains(n) {
-                    false
-                } else {
-                    queued.insert(*n);
-                    true
+            for dependent in self.dependents(node) {
+                if !queued.contains(&dependent) {
+                    queue.push_back(dependent);
+                    queued.insert(dependent);
                 }
-            }));
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
- Fix the `cycle_check` procedure.
- Use Kahn's algorithm in `walk_mut`. The previous implementation [was likely exponential](https://github.com/MeadowlarkDAW/audio-graph/commit/579f50772a44ed98da92e26e0f998f95c57cf4cb) in the amount of nodes.
- Change the schedule output order to match the order of computation. (Dependencies before dependents.) Not sure why it was `.rev()`'d.
- No longer require passing the `root` node into `compile()`. Kahn's algorithm has to find all sinks anyways, and so having multiple "roots" is now possible.